### PR TITLE
 Picking the "original" option when trying to import a file from Goog…

### DIFF
--- a/src/main/resources/GoogleApps/Groovy.xml
+++ b/src/main/resources/GoogleApps/Groovy.xml
@@ -44,7 +44,6 @@ import com.google.api.client.util.store.FileDataStoreFactory;
 
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.drive.Drive;
-import org.apache.tika.Tika;
 
 import com.google.api.client.http.ByteArrayContent;
 

--- a/src/main/resources/GoogleApps/Groovy.xml
+++ b/src/main/resources/GoogleApps/Groovy.xml
@@ -604,16 +604,20 @@ public class GoogleAppsGroovy {
         return result;
     }
 
-    public retrieveFileFromGoogle(page, name, id, url) {
-        return retrieveFileFromGoogle(getDriveService(), page, name, id, url);
+    public retrieveFileFromGoogle(page, name, id, url, mediaType) {
+        return retrieveFileFromGoogle(getDriveService(), page, name, id, url, mediaType);
     }
 
-    public retrieveFileFromGoogle(driveService, page, name, id, url) {
+    public retrieveFileFromGoogle(driveService, page, name, id, url, mediaType) {
         addDebug("Retrieving ${name} to page ${page}: ${id} ${url}" )
         def adoc = xwiki.getDocument(page);
         try {
-            String mt = new Tika().detect(name);
-            InputStream downloadStream = driveService.files().export(id, mt).executeMediaAsInputStream();
+            InputStream downloadStream;
+            if (mediaType) {
+                downloadStream = driveService.files().export(id, mediaType).executeMediaAsInputStream();
+            } else {
+                downloadStream = driveService.files().get(id).executeMediaAsInputStream();
+            }
             saveFileToXWiki(driveService, adoc, id, name, downloadStream, true);
             return id;
         } catch (Exception e) {

--- a/src/main/resources/GoogleApps/ImportFromGoogleApps.xml
+++ b/src/main/resources/GoogleApps/ImportFromGoogleApps.xml
@@ -59,11 +59,14 @@
 #set($result = $gagroovy.importFromGoogleApps("fullText contains ${squery}", 10))
 #foreach($entry in $result.items)
  #set($docName = $entry.title)
-* $docName  [[original&gt;&gt;RetrieveFromGoogleApps||queryString="page=${escapetool.url($request.page)}&amp;name=${escapetool.url($docName)}&amp;url=${escapetool.url($entry.selfLink)}&amp;editLink=${escapetool.url($entry.alternateLink)}&amp;version=${entry.version}&amp;id=${entry.id}"]] #foreach($elink in $entry.exportLinks)
-  #set($exportData = $gagroovy.getExportLink($docName, $elink))
-  #set($stype = $exportData.type)
-  #set($newDocName = $exportData.newDocName)
- [[${stype}&gt;&gt;RetrieveFromGoogleApps||queryString="page=${escapetool.url($request.page)}&amp;name=${escapetool.url($newDocName)}&amp;url=${escapetool.url($elink)}&amp;editLink=${escapetool.url($entry.alternateLink)}&amp;version=${entry.version}&amp;id=${entry.id}"]] #end
+ #if ($entry.exportLinks)
+    * $docName #foreach($elink in $entry.exportLinks.entrySet())
+    #set($exportData = $gagroovy.getExportLink($docName, $elink.value))
+    #set($stype = $exportData.type)
+    #set($newDocName = $exportData.newDocName)
+    [[${stype}&gt;&gt;RetrieveFromGoogleApps||queryString="page=${escapetool.url($request.page)}&amp;name=${escapetool.url($newDocName)}&amp;url=${escapetool.url($elink.value)}&amp;editLink=${escapetool.url($entry.alternateLink)}&amp;version=${entry.version}&amp;id=${entry.id}&amp;mt=${escapetool.url($elink.key)}"]] #end
+ #else
+    * $docName  [[original&gt;&gt;RetrieveFromGoogleApps||queryString="page=${escapetool.url($request.page)}&amp;name=${escapetool.url($docName)}&amp;url=${escapetool.url($entry.selfLink)}&amp;zeditLink=${escapetool.url($entry.alternateLink)}&amp;version=${entry.version}&amp;id=${entry.id}"]] #end
 
 #end
 #end

--- a/src/main/resources/GoogleApps/ImportFromGoogleApps.xml
+++ b/src/main/resources/GoogleApps/ImportFromGoogleApps.xml
@@ -60,13 +60,31 @@
 #foreach($entry in $result.items)
  #set($docName = $entry.title)
  #if ($entry.exportLinks)
-    * $docName #foreach($elink in $entry.exportLinks.entrySet())
-    #set($exportData = $gagroovy.getExportLink($docName, $elink.value))
-    #set($stype = $exportData.type)
+    * $docName #foreach($exportLink in $entry.exportLinks.entrySet())
+    #set($exportData = $gagroovy.getExportLink($docName, $exportLink.value))
     #set($newDocName = $exportData.newDocName)
-    [[${stype}&gt;&gt;RetrieveFromGoogleApps||queryString="page=${escapetool.url($request.page)}&amp;name=${escapetool.url($newDocName)}&amp;url=${escapetool.url($elink.value)}&amp;editLink=${escapetool.url($entry.alternateLink)}&amp;version=${entry.version}&amp;id=${entry.id}&amp;mt=${escapetool.url($elink.key)}"]] #end
+    [[$services.rendering.escape($exportData.type, 'xwiki/2.1')&gt;&gt;RetrieveFromGoogleApps||queryString="$services.rendering.escape(
+        $escapetool.url({
+          'page': $request.page,
+          'name': $newDocName,
+          'url':  $exportLink.value,
+          'editLink': $entry.alternateLink,
+          'version': $entry.version,
+          'id': $entry.id,
+          'mediaType': $exportLink.key
+        }), 'xwiki/2.1')"
+    ]] #end
  #else
-    * $docName  [[original&gt;&gt;RetrieveFromGoogleApps||queryString="page=${escapetool.url($request.page)}&amp;name=${escapetool.url($docName)}&amp;url=${escapetool.url($entry.selfLink)}&amp;zeditLink=${escapetool.url($entry.alternateLink)}&amp;version=${entry.version}&amp;id=${entry.id}"]] #end
+    * $docName  [[original&gt;&gt;RetrieveFromGoogleApps||queryString="$services.rendering.escape(
+        $escapetool.url({
+          'page': $request.page,
+          'name': $docName,
+          'url':  $entry.selfLink,
+          'editLink': $entry.alternateLink,
+          'version': $entry.version,
+          'id': $entry.id
+        }), 'xwiki/2.1')"
+    ]] #end
 
 #end
 #end

--- a/src/main/resources/GoogleApps/RetrieveFromGoogleApps.xml
+++ b/src/main/resources/GoogleApps/RetrieveFromGoogleApps.xml
@@ -40,7 +40,7 @@
 #set($gagroovy = $xwiki.parseGroovyFromPage("GoogleApps.Groovy"))
 #set($ok = $gagroovy.init($xwiki, $context, $doc))
 #if($request.url)
- #set($ok = $gagroovy.retrieveFileFromGoogle($request.page, $request.name, $request.id, $request.url, $request.mt))
+ #set($ok = $gagroovy.retrieveFileFromGoogle($request.page, $request.name, $request.id, $request.url, $request.mediaType))
  #if(!$ok)
 $services.localization.render("googleapps.retrieve.fail") $request.id
  #end

--- a/src/main/resources/GoogleApps/RetrieveFromGoogleApps.xml
+++ b/src/main/resources/GoogleApps/RetrieveFromGoogleApps.xml
@@ -40,7 +40,7 @@
 #set($gagroovy = $xwiki.parseGroovyFromPage("GoogleApps.Groovy"))
 #set($ok = $gagroovy.init($xwiki, $context, $doc))
 #if($request.url)
- #set($ok = $gagroovy.retrieveFileFromGoogle($request.page, $request.name, $request.id, $request.url))
+ #set($ok = $gagroovy.retrieveFileFromGoogle($request.page, $request.name, $request.id, $request.url, $request.mt))
  #if(!$ok)
 $services.localization.render("googleapps.retrieve.fail") $request.id
  #end


### PR DESCRIPTION
…le Apps is showing an error #66

The Google Drive API seems to handle downloading files in two different ways, depending on the file type. For OFFICE documents, one should export them into a specified format, while for other kind of files, they can be downloaded directly.

Our code seemed to use the same method for all kind of files (the exporting way). This caused two problems. 
1.When trying to download the original version of an office file, there was an error because we didn't specify any conversion format. 
2.The second problem was that we tried to download other kind of files (other than office) with the same method we were doing the exports. When trying to do this, a "Bad Request" was returned.

To solve these issues, I used a different download method depending on whether we received `exportFormats` from backend or not, for each file returned.