### PR TITLE
Editing a page that has an embeded document doesn't work properly #79

### DIFF
--- a/ui/src/main/resources/GoogleApps/DriveMacro.xml
+++ b/ui/src/main/resources/GoogleApps/DriveMacro.xml
@@ -331,7 +331,7 @@ if(!googleApps.active || !googleApps.useDrive) {
      if (editLink &amp;&amp; editLink.startsWith("http"))
        print """ - [[Edit&gt;&gt;url:${editLink}]]"""
      println ")))"
-     println """{{html}}&lt;iframe src="${embedLink}" width="${width}" height="${height}"&gt;&lt;/iframe&gt;{{/html}}"""
+     println """{{html clean=false}}&lt;div&gt;&lt;iframe src="${embedLink}" width="${width}" height="${height}"&gt;&lt;/iframe&gt;&lt;/div&gt;{{/html}}"""
     } else {
       def tquery = ""
       if (query)

--- a/ui/src/main/resources/GoogleApps/DriveMacro.xml
+++ b/ui/src/main/resources/GoogleApps/DriveMacro.xml
@@ -331,7 +331,7 @@ if(!googleApps.active || !googleApps.useDrive) {
      if (editLink &amp;&amp; editLink.startsWith("http"))
        print """ - [[Edit&gt;&gt;url:${editLink}]]"""
      println ")))"
-     println """{{html clean=false}}&lt;iframe src="${embedLink}" width="${width}" height="${height}"&gt;&lt;/iframe&gt;{{/html}}"""
+     println """{{html}}&lt;iframe src="${embedLink}" width="${width}" height="${height}"&gt;&lt;/iframe&gt;{{/html}}"""
     } else {
       def tquery = ""
       if (query)


### PR DESCRIPTION
* The issue was a more generic one. This behavior replicates with both Groovy and Velocity when the HTML has clean=false and we want to add text below an iframe. I've made an issue on the platform for this, and as a workaround, I removed the clean=false property.