### PR TITLE
The login screen includes the XWiki login twice #98

### DIFF
--- a/ui/src/main/resources/GoogleApps/LoginExtension.xml
+++ b/ui/src/main/resources/GoogleApps/LoginExtension.xml
@@ -128,7 +128,7 @@
       <code>#set($url = $xwiki.getURL("GoogleApps.Login", "view"))
 
 function loginWithXWiki() {
-    jQuery(".panel .panel-body dl").show()
+    jQuery('.panel .panel-body dl, .panel-body .submitSection').show();
     return false;
 }
 
@@ -150,7 +150,7 @@ require(['jquery', 'xwiki-events-bridge', 'xwiki-meta'], function($, xm) {
                 + '&lt;div style="clear: both;"&gt;&lt;/div&gt;&lt;/div&gt;').insertBefore(jQuery(".panel .panel-body dl"))
         }
         if (XWiki.contextaction != "loginsubmit") {
-            jQuery(".panel .panel-body dl").hide();
+            jQuery('.panel .panel-body dl, .panel-body .submitSection').hide();
         }
     }); // end document ready
 


### PR DESCRIPTION
* Updated the css selectors

Before:
<img width="418" height="279" alt="image" src="https://github.com/user-attachments/assets/8bf495f3-140f-4c16-abaa-1f932eb366a3" />

After:
<img width="416" height="209" alt="image" src="https://github.com/user-attachments/assets/546c2f2e-663a-4015-b5c3-1dea78f3cc05" />
